### PR TITLE
Handle missing CUDA gracefully

### DIFF
--- a/train_tiny_shakespeare_ff.py
+++ b/train_tiny_shakespeare_ff.py
@@ -336,7 +336,11 @@ def per_layer_optimizers(model: nn.Module, blocks: List[nn.Module],
 # ---------------------------
 
 def train_ff(args):
-    device = torch.device("cuda" if torch.cuda.is_available() and not args.cpu else "cpu")
+    use_cpu = getattr(args, "cpu", False)
+    if not use_cpu and not torch.cuda.is_available():
+        print("WARNING: CUDA is not available, falling back to CPU")
+        use_cpu = True
+    device = torch.device("cuda" if not use_cpu else "cpu")
     torch.manual_seed(args.seed)
     random.seed(args.seed)
 

--- a/ts_ff_generate.py
+++ b/ts_ff_generate.py
@@ -31,10 +31,14 @@ def main():
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--top_k", type=int, default=50)
     p.add_argument("--seed", type=int, default=1337)
-    p.add_argument("--cpu", action="store_true")
+    p.add_argument("--cpu", action="store_true", help="force CPU even if CUDA is available")
     args = p.parse_args()
 
-    device = torch.device("cpu" if args.cpu or not torch.cuda.is_available() else "cuda")
+    use_cpu = getattr(args, "cpu", False)
+    if not use_cpu and not torch.cuda.is_available():
+        print("WARNING: CUDA is not available, falling back to CPU")
+        use_cpu = True
+    device = torch.device("cuda" if not use_cpu else "cpu")
     torch.manual_seed(args.seed)
 
     model = load_model(args.ckpt, device)


### PR DESCRIPTION
## Summary
- avoid AttributeError when `--cpu` flag is absent and warn when CUDA is unavailable
- make generation script handle missing CUDA the same way

## Testing
- `python -m py_compile train_tiny_shakespeare_ff.py ts_ff_generate.py`


------
https://chatgpt.com/codex/tasks/task_e_68b06b42f1988325aed630e5ac1d11dd