### PR TITLE
Handle optional loss in cortex model

### DIFF
--- a/cortex/cortex_model.py
+++ b/cortex/cortex_model.py
@@ -127,7 +127,12 @@ class CortexModel(nn.Module):
         motor_state = self.motor_proj(H2[motor_idx])
         if motor_state.dim() == 3:
             motor_state = motor_state.mean(dim=0)
-        logp, loss, mfs_aux = self.mfs(motor_state, targets=targets)
+        mfs_out = self.mfs(motor_state, targets=targets)
+        if targets is not None:
+            logp, loss, mfs_aux = mfs_out
+        else:
+            logp, mfs_aux = mfs_out
+            loss = None
 
         # 5) Surprise/aha -> build broadcast messages
         if targets is not None:

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -158,6 +158,12 @@ def test_cortex_minimal():
     x_per_region[io_idxs['sensor']] = torch.randn(B, d_model)
     targets = torch.randint(0, vocab_size, (B,))
 
+    # Inference path should return a loss of None
+    logp, loss, aux = model(x_per_region)
+    assert logp.shape == (B, vocab_size)
+    assert loss is None
+
+    # Training path with targets should produce a finite loss
     logp, loss, aux = model(x_per_region, targets=targets)
     assert logp.shape == (B, vocab_size)
     assert loss is not None


### PR DESCRIPTION
## Summary
- fix unpacking when `targets=None` so cortex model handles optional loss
- extend smoke test to cover inference path and ensure loss is None without targets

## Testing
- `pytest smoke_test.py::test_cortex_minimal -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3891a3b1083258c2391c8e381dce2