### PR TITLE
Fix optional loss handling in MFS head

### DIFF
--- a/cortex/cortex_model.py
+++ b/cortex/cortex_model.py
@@ -127,12 +127,10 @@ class CortexModel(nn.Module):
         motor_state = self.motor_proj(H2[motor_idx])
         if motor_state.dim() == 3:
             motor_state = motor_state.mean(dim=0)
-        mfs_out = self.mfs(motor_state, targets=targets)
-        if targets is not None:
-            logp, loss, mfs_aux = mfs_out
-        else:
-            logp, mfs_aux = mfs_out
-            loss = None
+        # The MFS head always returns three outputs with ``loss`` set to ``None``
+        # when ``targets`` are not supplied.  This keeps the interface
+        # consistent between training and inference.
+        logp, loss, mfs_aux = self.mfs(motor_state, targets=targets)
 
         # 5) Surprise/aha -> build broadcast messages
         if targets is not None:


### PR DESCRIPTION
## Summary
- Return a consistent `(logp, loss, aux)` tuple from `MultiFacetSoftmax`, supplying `None` for loss during inference
- Simplify `CortexModel` forward pass to rely on the new MFS interface
- Update wrapper head to accommodate the new return signature

## Testing
- `python -m py_compile mfs.py cortex/cortex_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68b38b65615483259759b6698ad81fe5