### PR TITLE
Remove Lion and torch.compile dependencies

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -16,7 +16,7 @@ real_data = True
 seed = 1337
 device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
 dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32' or 'bfloat16' or 'float16'
-compile = True # use PyTorch 2.0 to compile the model to be faster
+compile = False # compilation requires triton; disable by default
 profile = False # use pytorch profiler, or just simple benchmarking?
 exec(open('configurator.py').read()) # overrides from command line or config file
 # -----------------------------------------------------------------------------

--- a/sample.py
+++ b/sample.py
@@ -19,7 +19,6 @@ top_k = 200 # retain only the top_k most likely tokens, clamp others to have 0 p
 seed = 1337
 device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
 dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32' or 'bfloat16' or 'float16'
-compile = False # use PyTorch 2.0 to compile the model to be faster
 exec(open('configurator.py').read()) # overrides from command line or config file
 # -----------------------------------------------------------------------------
 
@@ -50,8 +49,6 @@ elif init_from.startswith('gpt2'):
 
 model.eval()
 model.to(device)
-if compile:
-    model = torch.compile(model) # requires PyTorch 2.0 (optional)
 
 # look for the meta pickle in case it is available in the dataset folder
 load_meta = False

--- a/train.py
+++ b/train.py
@@ -71,7 +71,7 @@ backend = 'nccl' # 'nccl', 'gloo', etc.
 # system
 device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
 dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
-compile = True # use PyTorch 2.0 to compile the model to be faster
+compile = False # compilation requires triton; disable by default
 # -----------------------------------------------------------------------------
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
 exec(open('configurator.py').read()) # overrides from command line or config file
@@ -200,12 +200,6 @@ optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta
 if init_from == 'resume':
     optimizer.load_state_dict(checkpoint['optimizer'])
 checkpoint = None # free up memory
-
-# compile the model
-if compile:
-    print("compiling the model... (takes a ~minute)")
-    unoptimized_model = model
-    model = torch.compile(model) # requires PyTorch 2.0
 
 # wrap model into DDP container
 if ddp:

--- a/train_multitau_shakespeare.py
+++ b/train_multitau_shakespeare.py
@@ -2,10 +2,9 @@ import os
 import math
 import torch
 
-from cortex.cortex_model import CortexModel
 from cortex.io_patches import TextSensor
 from cortex.hexgrid import make_grid, build_adjacency
-from lion_pytorch import Lion
+from torch.optim import Adam
 
 
 # --------------------
@@ -69,6 +68,7 @@ R = len(hexes)
 io_idxs = {"sensor": 0, "motor": R - 1}
 print(f"Using {R} regions (grid {regions_w}x{regions_h}), d_model={d_model}")
 
+from cortex.cortex_model import CortexModel
 model = CortexModel(
     R=R,
     d_model=d_model,
@@ -87,10 +87,8 @@ sensor = TextSensor(
 for f in model.mfs.facets:
     f.weight = sensor.emb.weight
 
-if torch.cuda.is_available():
-    model = torch.compile(model, mode="max-autotune")
-
-optimizer = Lion(model.parameters(), lr=1.5e-4, betas=(0.9, 0.99), weight_decay=1e-2)
+# Using the standard Adam optimizer instead of Lion to avoid extra dependencies
+optimizer = Adam(model.parameters(), lr=1.5e-4, betas=(0.9, 0.99), weight_decay=1e-2)
 
 num_steps = 1000
 warmup_steps = 50


### PR DESCRIPTION
## Summary
- Replace `lion_pytorch` optimizer with standard `torch.optim.Adam`.
- Disable or remove `torch.compile` calls so the repo no longer requires Triton.
- Delay `CortexModel` import in `train_multitau_shakespeare.py` to avoid circular import errors.

## Testing
- `python smoke_test.py --device=cpu --batch=1 --seq=8 --block=16`
- `timeout 5 python train_multitau_shakespeare.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4afd09e7083258d47dee0a2eb1dd2